### PR TITLE
added DevNews in podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Initially created by [Marko Denic](https://twitter.com/denicmarko) on [Twitter](
 | [JAMStack Radio](https://www.heavybit.com/library/podcasts/jamstack-radio/) |  
 | [Modern Web](https://www.thisdot.co/modern-web) | 
 | [DevDiscuss](https://dev.to/devdiscuss) |
+| [DevNews](https://dev.to/devnews) |
 | [React Native Radio](https://reactnativeradio.com/) |
 
 [⬆ back to top](#table-of-contents)


### PR DESCRIPTION
DevNews is the news show for developers by developers, hosted by Saron Yitbarek, founder of CodeNewbie, and DEV senior engineers Josh Puetz and Vaidehi Joshi.