### PR TITLE
Should zoop.sh be removed?

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Initially created by [Marko Denic](https://twitter.com/denicmarko) on [Twitter](
 | https://render.com |  
 | https://docs.gitlab.com/ee/user/project/pages |  
 | https://stormkit.io |  
-| https://www.zoop.sh |
 | https://www.digitalocean.com/ |
 
 [⬆ back to top](#table-of-contents)


### PR DESCRIPTION
First, thanks for putting together this great list of resources!

I just noticed that the website of [zoop.sh](zoop.sh) looks like its not accessible anymore. The website gives an '403 Forbidden' error and the SSL cert is expired. 

To me it seems that zoop.sh has stopped offering its services and that it would therefore be logical to remove it.