### PR TITLE
Add Open App Academy resource under Learning Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 | https://www.guru99.com/ |
 | https://trailhead.salesforce.com/ |
 | https://ocw.mit.edu/ |
+| https://open.appacademy.io/ |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
- Add https://open.appacademy.io resource under learning platforms

- Open App Academy is the open and free version of one of the greatest boot camps in the US. Based on Rails and React (but they are adding more languages and frameworks). The curriculum is the same as the paid one but without mentors' support.