### PR TITLE
Add: Colorzilla chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 | [Performance-Analyser](https://chrome.google.com/webstore/detail/performance-analyser/djgfmlohefpomchfabngccpbaflcahjf) |
 | [WhatFont](https://chrome.google.com/webstore/detail/whatfont/jabopobgcpjmedljpbcaablpmlmfcogm?hl=en) |  
 | [Visbug](https://chrome.google.com/webstore/detail/visbug/cdockenadnadldjbbgcallicgledbeoc/related) |
+| [Colorzilla](https://chrome.google.com/webstore/detail/colorzilla/bhlhnicpbhignbdhedgjhgdocnmhomnp?hl=en-US) |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Colorzilla chrome extension. To pick colors from a webpage.

https://chrome.google.com/webstore/detail/colorzilla/bhlhnicpbhignbdhedgjhgdocnmhomnp?hl=en-US