### PR TITLE
Fix duplicated Traversy Media Youtube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 | [Adrian Twarog](https://www.youtube.com/channel/UCvM5YYWwfLwpcQgbRr68JLQ) |
 | [Wes Bos](https://www.youtube.com/wesbos) |
 | [DesignCourse](https://www.youtube.com/c/DesignCourse) |
-| [Traversy Media](https://www.youtube.com/c/TraversyMedia)|
 | [codedamn](https://www.youtube.com/c/codedamn) |
 | [ProgrammingWithMosh](https://www.youtube.com/c/programmingwithmosh) |
 


### PR DESCRIPTION
Currently the Youtube Channels list contains two links to [Traversy Media](https://www.youtube.com/c/TraversyMedia)'s channel, one at the very top of the list and another one towards the end of the list, this pull request removes the second link.