### PR TITLE
Add code.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 | https://www.codementor.io/events                                 |
 | https://eloquentjavascript.net/                                  |
 | https://skillcombo.com/courses/development/web-development/free/ |
+| https://code.org/                                                |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Added https://code.org/, an educational site focused on teaching computer science and programming to younger people and students.