### PR TITLE
Add remotescout.ch to remote jobboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 | https://angel.co                |
 | https://www.smartremotejobs.com |
 | https://www.remotehub.com       |
+| https://www.remotescout.ch      |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
RemoteScout is a jobboard for remote and hybrid jobs in Germany, Austria and Switzerland (other Europeans countries to come)
[remotescout.ch](https://remotescout.ch)