### PR TITLE
Add 'Videos' link to Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Initially created by [Marko Denic](https://markodenic.com) on [Twitter](https://
 - [Freelancing platforms](#freelancing-platforms)
 - [Remote Jobs](#remote-jobs)
 - [Photos](#photos)
+- [Videos](#videos)
 - [Illustrations](#illustrations)
 - [Icons](#icons)
 - [Fonts](#fonts)


### PR DESCRIPTION
To aid navigation, I added a link to the 'videos' resources section, in the table of contents