### PR TITLE
Change url of Tabler Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | https://css.gg                            |
 | https://lineicons.com                     |
 | https://remixicon.com                     |
-| https://tablericons.com                   |
+| https://tabler-icons.io                   |
 | https://simpleicons.org                   |
 | https://feathericons.com                  |
 | https://svgrepo.com                       |


### PR DESCRIPTION
Official website of Tabler Icons is https://tabler-icons.io. tablericons.com is in no way associated with our project

Paweł,
author of Tabler Icons