### PR TITLE
Remove obsolete jobs boards, add JobsCollider

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | https://nowhiteboard.org             |
 | https://www.coolstartupjobs.com      |
 | https://wellfound.com/               |
-| https://www.smartremotejobs.com      |
 | https://www.remotehub.com            |
 | https://startup.jobs/remote-jobs     |
 | https://jobsinjs.com                 | 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 
 | Website                              |
 |--------------------------------------|
+| https://jobscollider.com/remote-jobs |
 | https://workremote.cc/               |
 | https://www.showwcase.com/jobs       |
 | https://www.remotefrontendjobs.com/  |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | https://wellfound.com/               |
 | https://www.remotehub.com            |
 | https://startup.jobs/remote-jobs     |
-| https://jobsinjs.com                 | 
 | https://echojobs.io                  |
 | https://AiJobsTracker.com/remote     |
 | https://www.remote.io                |


### PR DESCRIPTION
Hi @markodenic,

I've removed obsolete jobs boards:
- http://www.smartremotejobs.com/ - has no jobs
- jobsinjs.com - has no updates for over a year

Also, I would like to add my remote jobs board: https://jobscollider.com/remote-jobs
I scan 10,000+ companies every day to gather all open jobs, classify each job, filter for remote positions, and post them

Thanks, 
-Max