### PR TITLE
Add Chroma Palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 |-------------------------------|
 | https://coolors.co            |
 | https://colorhunt.co          |
+| https://chromapalette.in/     |
 | https://paletton.com          |
 | https://color-hex.com         |
 | https://mycolor.space         |


### PR DESCRIPTION
Chroma Palette 🎨 is a chrome extension to extract, pick and manage the dominant color palette from the visible area of any webpage or pick and manage specific color palettes using an uploaded image.