### PR TITLE
Add Speaking Time Calculator Tool

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -614,6 +614,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [ToolZack](https://toolzack.com)                                                 | A friendly web toolkit for converting, encoding, formatting and styling text. Over 120 free tools.                        |
 | [AutoChangelog](https://autochangelog.com)                                       | Automatically turn pull requests, code changes, and commits into readable changelogs.                                     |
 | [Preflight](https://preflight.sh)                                                | Stop embarrassing yourself in production. Scan your codebase for launch readiness before you ship.                        |
+| [Speaking Time Calculator](https://speakingtimecalculator.org)                   | A free online tool to estimate speaking or presentation time based on text length and speaking pace (WPM).                  |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
### Added Speaking Time Calculator

This PR adds a free online tool that helps estimate speaking or presentation time based on text length and adjustable speaking pace (WPM).

The tool is lightweight, browser-based, and useful for developers, educators, and content creators preparing talks, demos, or presentations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Speaking Time Calculator to the Online Tools section with relevant URL and description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->