### PR TITLE
Add DevToolBox to Online Tools section

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -603,6 +603,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [AutoChangelog](https://autochangelog.com)                                       | Automatically turn pull requests, code changes, and commits into readable changelogs.                                     |
 | [Preflight](https://preflight.sh)                                                | Stop embarrassing yourself in production. Scan your codebase for launch readiness before you ship.                        |
 | [Speaking Time Calculator](https://speakingtimecalculator.org)                   | A free online tool to estimate speaking or presentation time based on text length and speaking pace (WPM).                  |
+| [DevToolBox](https://viadreams.cc)                                               | 129+ free online developer tools: JSON formatter, Base64 encoder, JWT decoder, regex tester, hash generator, and more. 100% client-side, no data sent to servers. |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
## Add DevToolBox to Online Tools

Hi! I'd like to add [DevToolBox](https://viadreams.cc) to the **Online Tools** section.

**Link:** https://viadreams.cc

**Description:** DevToolBox offers 129+ free online developer tools including JSON formatter, Base64 encoder/decoder, JWT decoder, regex tester, hash generator, color converter, and more. All processing is done 100% client-side — no data is sent to servers.

- Completely free, no signup required
- Open source
- Supports 15 languages

Thank you for maintaining this awesome list!