### PR TITLE
Add SnapAPI to Online Tools

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -605,6 +605,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [AutoChangelog](https://autochangelog.com)                                       | Automatically turn pull requests, code changes, and commits into readable changelogs.                                     |
 | [Preflight](https://preflight.sh)                                                | Stop embarrassing yourself in production. Scan your codebase for launch readiness before you ship.                        |
 | [Speaking Time Calculator](https://speakingtimecalculator.org)                   | A free online tool to estimate speaking or presentation time based on text length and speaking pace (WPM).                  |
+| [SnapAPI](https://api-snap.com)                                                  | Multi-tool utility API with 13+ endpoints: QR codes, screenshots, HTML-to-PDF, image resize, hashing, UUID, base64, JWT decode, URL metadata, and more. Free tier with 100 calls/month. |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
## Add SnapAPI to Online Tools

Adding [SnapAPI](https://api-snap.com) to the Online Tools section.

**Link:** https://api-snap.com

**Description:** SnapAPI is a multi-tool utility API with 13+ endpoints including QR codes, screenshots, HTML-to-PDF, image resize, hashing, UUID, base64, JWT decode, URL metadata, and more. It offers a free tier with 100 calls/month, no credit card required.