### PR TITLE
Add 'Related Repos' link to Chrome Extensions

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -491,6 +491,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [React Developer Tools](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)                      |
 | [Hackertab.dev - All Developer news in 1 tab](https://chromewebstore.google.com/detail/hackertabdev-developer-ne/ocoipcahhaedjhnpoanfflhbdcpmalmp)  |
 | [Vue Developer Tools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)                                     |
+| [Related Repos](https://chromewebstore.google.com/detail/related-repos/hjjchbgenhmnndipngamcilolaahgngc)                                     |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
## Requirements
* [x] This is a specific resource, **NOT** a collection or directory of tools
* [x] It has a free tier not just a free trial
* [x] Pricing information is clearly visible without signup or phone calls
* [x] The submission mentions what is free
* [x] The submission is not already present in the list
* [x] I have placed this in the correct category and alphabetical order
* [x] I have manually verified that this resource provides immediate value
<!--
 Contributing here is very easy, but does require attention to details.
 We do not accept LLM written submissions.
-->
* [ ] Large Language Models and other AI tick this box

[Related Repos](https://relatedrepos.com/) helps developers to discover open source projects that are related to each other. This can be useful to find alternative or complementary packages when building a full application. Or you can simply surf around in different neighborhoods to find new ideas that you might not have been aware of.

Data and results are updated daily so you can keep coming back to discover fresh repositories. Results can be thought of as "users who expressed interest in this repository also expressed interest in these other repositories".