### PR TITLE
Add daily.dev Digest to Newsletters

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -542,6 +542,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [Accessibility Weekly](https://a11yweekly.com/)                                        | Accessibility.                                                  |
 | [UI Dev Newsletter](https://www.silvestar.codes/side-projects/ui-dev-mentoring/reads/) | User Interface development.                                     |
 | [Go Make Things](https://gomakethings.com/)                                            | Daily Vanilla JavaScript.                                       |
+| [daily.dev Digest](https://business.daily.dev)                                         | Personalised developer-news digest delivered daily or weekly.   |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Adds **daily.dev Digest** to the Newsletters section.

- **Link:** https://business.daily.dev
- **Description:** Personalised developer-news digest delivered daily or weekly.
- **Free tier:** Yes — free to subscribe; you choose daily or weekly cadence and the topics you follow.

**Disclosure:** I work at daily.dev. The Chrome Extension is already listed under Chrome Extensions, which is great — the Digest is a separate surface (email newsletter) that complements the existing entries here (Frontend Focus, JavaScript Weekly, Smashing Newsletter, etc.) for readers who want curated dev news in their inbox rather than as a new-tab feed.

Per CONTRIBUTING.md: one item, free tier, on-topic for the section, under the 10-item soft cap. Happy to tweak the description or pull this if you'd rather keep the section as-is.