### PR TITLE
Add Flexbox Zombies to CSS Games

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -576,6 +576,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [Guess CSS](https://www.guess-css.app/)                                               | Another Fun and interactive way to learn CSS.                                                                                                                                         |
 | [CSS Speedrun](https://css-speedrun.netlify.app/)                                     | A CSS speedrun is a challenge to see how quickly a developer can complete a task using only CSS (Cascading Style Sheets).                                                             |
 | [Anchoreum](https://anchoreum.com/)                                                   | A game for learning CSS anchor positioning.                                                                                                                                           |
+| [Flexbox Zombies](https://flexboxzombies.com/)                                        | A story-driven course-game where you learn **CSS Flexbox** by hunting zombies across 12 missions.                                                                                     |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
## Resource
[Flexbox Zombies](https://flexboxzombies.com/)

## Description
A story-driven course-game by Mastery Games where you learn **CSS Flexbox** by hunting zombies across 12 missions. Originally a paid course, made completely free in 2020 (free signup required).

## Category
**CSS Games** (8 items before this PR — under the 10-item cap).

## Checklist
- [x] One item per PR
- [x] Resource is completely free
- [x] Target category had fewer than 10 items
- [x] Not already listed (verified across the README)