### PR TITLE
Add Payload Components to React UI libraries

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -654,6 +654,8 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [NativeBase](https://nativebase.io/)                  | NativeBase is an accessible, utility-first component library that helps you build consistent UI across Android, iOS and Web.    |
 | [Prime React](https://primereact.org/)                | The ultimate collection of design-agnostic, flexible and accessible React UI Components.                                        |
 
+| [Payload Components](https://www.payload-components.xyz) | 67 MIT typed Payload CMS blocks for Payload v3 + Next.js 15/16, installed as owned source with automated Pages, renderer, types, and admin import-map wiring. |
+
 [⬆ back to top](#table-of-contents)
 
 ## Angular UI libraries:


### PR DESCRIPTION
web-development-resources uses its React UI libraries table to direct developers to reusable component systems and their practical value.

The [Payload Components](https://www.payload-components.xyz) entry helps the Payload v3 segment ship Next.js 15/16 pages faster: 67 MIT typed blocks arrive as client-owned source, with Pages registration, renderer mapping, generated types, and the admin import map handled by the CLI. The result stays transparent and customizable in git.

This contribution is a single two-column table row in the established React section.