### PR TITLE
Add WhatFontFinder to Fonts

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -301,6 +301,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [Urban Fonts](https://urbanfonts.com)         |
 | [Fontpair](https://www.fontpair.co)           |
 | [Fonts Bunny](https://fonts.bunny.net)        |
+| [WhatFontFinder](https://whatfontfinder.com)  |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Resource link: **https://whatfontfinder.com**

One item, added to `## Fonts:` in `list/README.md`.

**Short description:** Free font site with a browser-based font identifier — crop lettering out of any image and it matches the shapes against 1,837 Google Fonts and 316 pop-culture typefaces. Also hosts ~170 downloadable typeface pages (movie, game, TV, band and brand lettering), each naming the designer and stating that font's licence individually rather than lumping everything under "free".

**Checked against CONTRIBUTING.md before opening:**

- One item per PR. ✅
- Completely free: no account, no signup, no paywall on any of it. ✅
- Not a category with 10+ resources — `Fonts:` currently has 9, so this is the 9→10 slot rather than piling onto a full category. ✅
- Not an SEO farm: the identifier is a real client-side tool, not a thin content page. I checked the tool JS — there is no `FormData` or XHR upload path, only `fetch()` calls that pull font files and previews down, so the cropped image genuinely never leaves the browser.
- Column padding matches the existing rows exactly (49 chars), so the table still renders aligned in raw view.

**While I was in there** I tested all 9 existing links in the `Fonts:` section — every one returns 200, so there is nothing to clean up. Two harmless redirects if you ever want to tidy: `https://fontspace.com` → `https://www.fontspace.com/` and `https://www.fontpair.co` → `https://fontpair.co/`. Not worth a commit on their own, just noting it since I had the results.

Happy to reword the entry or close this if it is not the right fit.