### PR TITLE
Add Nutilz — free browser-based developer tools

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -610,6 +610,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [Preflight](https://preflight.sh)                                                | Stop embarrassing yourself in production. Scan your codebase for launch readiness before you ship.                                                                                                                   |
 | [Speaking Time Calculator](https://speakingtimecalculator.org)                   | A free online tool to estimate speaking or presentation time based on text length and speaking pace (WPM).                                                                                                           |
 | [IconKing](https://iconking.net) | Free browser-based Lottie animation viewer, color editor, and format converter. Preview .json and .lottie files, edit colors across all layers, and convert between formats. No signup required.
+| [Nutilz](https://nutilz.com) | 23 free browser-based developer tools: regex tester, JSON formatter, unit converter, calculators, and more. All run in-browser with no sign-up required. |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Nutilz (https://nutilz.com) offers 23 free tools including regex tester, JSON formatter, unit converter, and calculators. All run in-browser, no sign-up needed. Resource link: https://nutilz.com