### PR TITLE
Add Knocket to Online Tools section

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -610,6 +610,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [Preflight](https://preflight.sh)                                                | Stop embarrassing yourself in production. Scan your codebase for launch readiness before you ship.                                                                                                                   |
 | [Speaking Time Calculator](https://speakingtimecalculator.org)                   | A free online tool to estimate speaking or presentation time based on text length and speaking pace (WPM).                                                                                                           |
 | [IconKing](https://iconking.net) | Free browser-based Lottie animation viewer, color editor, and format converter. Preview .json and .lottie files, edit colors across all layers, and convert between formats. No signup required.
+| [Knocket](https://knocket.com)                                                   | Free-forever live chat widget for websites. One script tag to embed, unified Telegram/email inbox, shareable contact page, no seat limits, no ads.                                                                   |
 
 [⬆ back to top](#table-of-contents)
 


### PR DESCRIPTION
Add [Knocket](https://knocket.com) to the Online Tools section.

Knocket is a free-forever live chat widget for websites. One script tag to embed, unified Telegram/email inbox, shareable contact page, no seat limits, no ads.