### PR TITLE
Add The Concise TypeScript Book to Docs

### DIFF
--- a/list/README.md
+++ b/list/README.md
@@ -431,6 +431,7 @@ Initially created by [Marko](https://markodenic.com) at [Web Development Resourc
 | [W3Schools](https://w3schools.com)                   |
 | [W3Docs](https://w3docs.com)                         |
 | [DevDocs](https://devdocs.io)                        |
+| [The Concise TypeScript Book](https://github.com/gibbok/typescript-book) | A free and open-source TypeScript book covering fundamentals through advanced concepts, available online and as an EPUB. |
 | [PHP.net](https://www.php.net/docs.php)              |
 
 [⬆ back to top](#table-of-contents)


### PR DESCRIPTION
Hi! Thanks for maintaining this resource.

I thought [The Concise TypeScript Book](https://github.com/gibbok/typescript-book) might be a useful addition to the Docs section. It is free and open source, has 10,300+ stars on GitHub, and was recently updated for TypeScript 7.

I followed the existing table format and kept this to one resource. Please feel free to suggest any changes, or close the PR if it is not a good fit.

Thanks for your time and for maintaining the project.